### PR TITLE
fix(gateway): stop benching domains for our own cancellations; dedupe websocket health checks

### DIFF
--- a/gateway/circuit_breaker_batch_client_cancel_test.go
+++ b/gateway/circuit_breaker_batch_client_cancel_test.go
@@ -41,7 +41,7 @@ func TestProcessSinglePayloadWithRetry_ClientCancelDoesNotFeedCircuitBreaker(t *
 	// The control deliberately does NOT use context.Canceled. An endpoint cannot cancel our
 	// context — only we can — so a cancel is never evidence about the endpoint, whether or
 	// not the client's own context is still live. The original control asserted the
-	// opposite and encoded the hedge-cancel bug as expected behaviour: the hedge racer
+	// opposite and encoded the hedge-cancel bug as expected behavior: the hedge racer
 	// cancels the primary branch's detached context on every exit path, and a batch item
 	// falling through from the race reused it, so "cancel + live parent" was reached in
 	// production constantly and benched healthy operators. connection refused is what a
@@ -118,7 +118,7 @@ type transportErrorProtocolCtx struct {
 	onRelay  func()
 	calls    int
 	// relayErr is the wrapped cause the relay fails with. Nil means context.Canceled,
-	// the shape a cancelled in-flight request produces.
+	// the shape a canceled in-flight request produces.
 	relayErr error
 }
 

--- a/gateway/circuit_breaker_batch_client_cancel_test.go
+++ b/gateway/circuit_breaker_batch_client_cancel_test.go
@@ -38,13 +38,24 @@ func TestProcessSinglePayloadWithRetry_ClientCancelDoesNotFeedCircuitBreaker(t *
 		domain    = "a.example.com"
 	)
 
+	// The control deliberately does NOT use context.Canceled. An endpoint cannot cancel our
+	// context — only we can — so a cancel is never evidence about the endpoint, whether or
+	// not the client's own context is still live. The original control asserted the
+	// opposite and encoded the hedge-cancel bug as expected behaviour: the hedge racer
+	// cancels the primary branch's detached context on every exit path, and a batch item
+	// falling through from the race reused it, so "cancel + live parent" was reached in
+	// production constantly and benched healthy operators. connection refused is what a
+	// genuinely broken endpoint produces, and that must still break.
+	connRefused := errors.New("dial tcp 10.0.0.1:443: connect: connection refused")
 	for _, tc := range []struct {
 		name         string
 		cancelParent bool
+		relayErr     error
 		wantFailures int
 	}{
 		{name: "client hung up mid-relay", cancelParent: true, wantFailures: 0},
-		{name: "genuine transport error (control)", cancelParent: false, wantFailures: 1},
+		{name: "cancel with the client context still live (hedge race)", cancelParent: false, wantFailures: 0},
+		{name: "genuine transport error (control)", cancelParent: false, relayErr: connRefused, wantFailures: 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -53,6 +64,7 @@ func TestProcessSinglePayloadWithRetry_ClientCancelDoesNotFeedCircuitBreaker(t *
 			cb := NewDomainCircuitBreaker(nil, testCircuitBreakerLogger())
 			protocolCtx := &transportErrorProtocolCtx{
 				endpoint: endpoint,
+				relayErr: tc.relayErr,
 				onRelay: func() {
 					if tc.cancelParent {
 						cancel()
@@ -105,13 +117,20 @@ type transportErrorProtocolCtx struct {
 	endpoint protocol.EndpointAddr
 	onRelay  func()
 	calls    int
+	// relayErr is the wrapped cause the relay fails with. Nil means context.Canceled,
+	// the shape a cancelled in-flight request produces.
+	relayErr error
 }
 
 func (m *transportErrorProtocolCtx) HandleServiceRequest([]protocol.Payload) ([]protocol.Response, error) {
 	m.calls++
 	m.onRelay()
+	cause := m.relayErr
+	if cause == nil {
+		cause = context.Canceled
+	}
 	return nil, fmt.Errorf("relay: error sending relay: %w: connection error: Post \"https://a.example.com\": %w",
-		errors.New("HTTP relay request failed"), context.Canceled)
+		errors.New("HTTP relay request failed"), cause)
 }
 
 func (m *transportErrorProtocolCtx) SetParentContext(context.Context) {}
@@ -128,6 +147,10 @@ type pluggableCtxProtocol struct {
 	mockProtocolForRetry
 	endpoints   protocol.EndpointAddrList
 	protocolCtx ProtocolRequestContext
+	// onBuild, when set, fires on every protocol-context build. Lets a test see the
+	// ORDER of builds and relays, which is what distinguishes a fallthrough that reused
+	// a context from one that rebuilt it.
+	onBuild func()
 }
 
 func (m *pluggableCtxProtocol) AvailableHTTPEndpoints(
@@ -139,5 +162,8 @@ func (m *pluggableCtxProtocol) AvailableHTTPEndpoints(
 func (m *pluggableCtxProtocol) BuildHTTPRequestContextForEndpoint(
 	_ context.Context, _ protocol.ServiceID, _ protocol.EndpointAddr, _ sharedtypes.RPCType, _ *http.Request, _ bool,
 ) (ProtocolRequestContext, protocolobservations.Observations, error) {
+	if m.onBuild != nil {
+		m.onBuild()
+	}
 	return m.protocolCtx, protocolobservations.Observations{}, nil
 }

--- a/gateway/health_check_executor.go
+++ b/gateway/health_check_executor.go
@@ -2013,25 +2013,7 @@ func (e *HealthCheckExecutor) runEndpointChecks(
 			// TrySubmit rather than Submit: when the websocket pool is saturated the
 			// right move is to SKIP this round, not to queue. A skipped check costs a
 			// refresh interval; a growing queue reintroduces the stall it is avoiding.
-			wsCheck := check
-			wsEndpoint := endpointAddr
-			wsAllowance := syncAllowance
-			if e.wsPool != nil {
-				if _, ok := e.wsPool.TrySubmit(func() {
-					if ctx.Err() != nil {
-						return
-					}
-					latency, err := e.ExecuteWebSocketCheckViaProtocol(ctx, serviceID, wsEndpoint, wsCheck, wsAllowance)
-					e.recordCheckResult(ctx, serviceID, wsEndpoint, wsCheck, err, latency)
-				}); !ok {
-					e.logger.Debug().
-						Str("service_id", string(serviceID)).
-						Str("endpoint", string(wsEndpoint)).
-						Str("check", wsCheck.Name).
-						Uint64("ws_pool_waiting", e.wsPool.WaitingTasks()).
-						Msg("websocket check skipped this round - check pool saturated")
-				}
-			}
+			e.submitWebsocketCheck(ctx, serviceID, endpointAddr, check, syncAllowance, nil)
 		case HealthCheckTypeGRPC:
 			// gRPC checks not yet implemented
 			e.logger.Debug().
@@ -2054,6 +2036,122 @@ func (e *HealthCheckExecutor) runEndpointChecks(
 		}
 	}
 	return httpOutcomes
+}
+
+// submitWebsocketCheck runs ONE websocket probe off the health-check cycle and records
+// its result for probeAddr plus every address in fanTo.
+//
+// Run OFF the cycle. See wsPool: a websocket check can block for its full timeout, and
+// the cycle waits on everything it submits, so keeping these inline lets one silent
+// endpoint throttle every other check in the gateway.
+//
+// TrySubmit rather than Submit: when the websocket pool is saturated the right move is
+// to SKIP this round, not to queue. A skipped check costs a refresh interval; a growing
+// queue reintroduces the stall it is avoiding.
+//
+// fanTo carries the suppliers that share probeAddr's backend websocket URL. They are
+// RECORDED, never skipped: a websocket probe is a property of the backend, so a broken
+// backend must move every sharing supplier's websocket reputation key. Skipping them
+// would penalize only the probed supplier and leave its siblings on the same backend
+// clean and selectable — the endpoint would be reached anyway, through a different
+// supplier address.
+func (e *HealthCheckExecutor) submitWebsocketCheck(
+	ctx context.Context,
+	serviceID protocol.ServiceID,
+	probeAddr protocol.EndpointAddr,
+	check HealthCheckConfig,
+	syncAllowance uint64,
+	fanTo []protocol.EndpointAddr,
+) {
+	if e.wsPool == nil {
+		return
+	}
+	if _, ok := e.wsPool.TrySubmit(func() {
+		if ctx.Err() != nil {
+			return
+		}
+		latency, err := e.ExecuteWebSocketCheckViaProtocol(ctx, serviceID, probeAddr, check, syncAllowance)
+		e.recordCheckResult(ctx, serviceID, probeAddr, check, err, latency)
+		for _, addr := range fanTo {
+			e.recordCheckResult(ctx, serviceID, addr, check, err, latency)
+			metrics.RecordHealthCheckDeduped(string(serviceID))
+		}
+	}); !ok {
+		e.logger.Debug().
+			Str("service_id", string(serviceID)).
+			Str("endpoint", string(probeAddr)).
+			Str("check", check.Name).
+			Uint64("ws_pool_waiting", e.wsPool.WaitingTasks()).
+			Msg("websocket check skipped this round - check pool saturated")
+	}
+}
+
+// submitDedupedWebsocketChecks fires ONE websocket handshake per distinct backend
+// websocket URL held by members, and records that result for every supplier sharing it.
+//
+// HTTP checks were deduplicated by backend URL; websocket checks were not, so a backend
+// carrying N supplier registrations took N full TCP+TLS+WS handshakes per cycle where
+// HTTP took one. Measured 2026-09-05: 29.85 websocket checks/s fleetwide, of which 6.62/s
+// landed on a single operator and arrived as ~3/s of full-TLS handshakes per gateway
+// egress IP — enough for that operator to read it as an attack. Stacked registrations are
+// common (four registrations behind one URL on one service), so the multiplier tracks how
+// a provider spreads its registrations, not how much traffic it serves.
+//
+// Members with no websocket URL, or whose session has ended, are left out entirely: a skip
+// is neither a pass nor a failure, and recording either would invent a signal.
+func (e *HealthCheckExecutor) submitDedupedWebsocketChecks(
+	ctx context.Context,
+	serviceID protocol.ServiceID,
+	svcConfig *ServiceHealthCheckConfig,
+	cycle uint64,
+	members []EndpointInfo,
+) {
+	var syncAllowance uint64
+	if svcConfig.SyncAllowance != nil && *svcConfig.SyncAllowance > 0 {
+		syncAllowance = uint64(*svcConfig.SyncAllowance)
+	}
+
+	byWSURL := make(map[string][]protocol.EndpointAddr)
+	for _, m := range members {
+		if m.WebSocketURL == "" {
+			continue
+		}
+		if !e.endpointSessionActive(ctx, serviceID, m) {
+			continue
+		}
+		byWSURL[m.WebSocketURL] = append(byWSURL[m.WebSocketURL], m.Addr)
+	}
+	if len(byWSURL) == 0 {
+		return
+	}
+
+	urls := make([]string, 0, len(byWSURL))
+	for u := range byWSURL {
+		urls = append(urls, u)
+	}
+	sort.Strings(urls)
+
+	for _, check := range svcConfig.Checks {
+		if check.Type != HealthCheckTypeWebSocket {
+			continue
+		}
+		for _, u := range urls {
+			addrs := byWSURL[u]
+			// Sorted so the rotation below is stable across cycles and pods.
+			sort.Slice(addrs, func(i, j int) bool { return addrs[i] < addrs[j] })
+			// Rotate which supplier carries the handshake, so each one's own websocket
+			// path is directly probed every len(addrs) cycles rather than one supplier
+			// answering for the group forever.
+			repIdx := representativeIndex(cycle, len(addrs))
+			fanTo := make([]protocol.EndpointAddr, 0, len(addrs)-1)
+			for i, addr := range addrs {
+				if i != repIdx {
+					fanTo = append(fanTo, addr)
+				}
+			}
+			e.submitWebsocketCheck(ctx, serviceID, addrs[repIdx], check, syncAllowance, fanTo)
+		}
+	}
 }
 
 // fanOutcomeToSibling replays a representative's HTTP check outcomes onto a sibling
@@ -2500,13 +2598,15 @@ func (e *HealthCheckExecutor) RunAllChecksViaProtocol(
 					}
 				}
 
+				// runWS=false on both the representative and the siblings: websocket
+				// checks are deduplicated by backend WEBSOCKET url below, which is a
+				// different grouping from this HTTP-url group.
 				var outcomes []checkOutcome
 				if e.endpointSessionActive(ctx, serviceID, rep) {
-					outcomes = e.runEndpointChecks(ctx, serviceID, rep.Addr, &cfg, true, true, rep.WebSocketURL != "")
+					outcomes = e.runEndpointChecks(ctx, serviceID, rep.Addr, &cfg, true, false, rep.WebSocketURL != "")
 				}
 
-				// Siblings: fan the representative's HTTP outcomes (no relay), and still
-				// probe each sibling's own WebSocket connectivity (per-endpoint).
+				// Siblings: fan the representative's HTTP outcomes (no relay).
 				for i := range grp {
 					if i == repIdx {
 						continue
@@ -2521,8 +2621,10 @@ func (e *HealthCheckExecutor) RunAllChecksViaProtocol(
 					if len(outcomes) > 0 {
 						e.fanOutcomeToSibling(ctx, serviceID, sib.Addr, outcomes)
 					}
-					e.runEndpointChecks(ctx, serviceID, sib.Addr, &cfg, false, true, sib.WebSocketURL != "")
 				}
+
+				// One handshake per distinct backend websocket URL in this group.
+				e.submitDedupedWebsocketChecks(ctx, serviceID, &cfg, cycle, grp)
 			})
 			totalJobs++
 		}

--- a/gateway/hedge_fallthrough_rebuild_test.go
+++ b/gateway/hedge_fallthrough_rebuild_test.go
@@ -82,5 +82,5 @@ func TestProcessSinglePayloadWithRetry_HedgeFallthroughRebuildsProtocolContext(t
 	c.Equal("relay", trace[len(trace)-1], "the fallthrough must end in a relay: %v", trace)
 	c.Equal("build", trace[len(trace)-2],
 		"the fallthrough relay must use a freshly built protocol context, not the one the "+
-			"hedge race cancelled: %v", trace)
+			"hedge race canceled: %v", trace)
 }

--- a/gateway/hedge_fallthrough_rebuild_test.go
+++ b/gateway/hedge_fallthrough_rebuild_test.go
@@ -1,0 +1,86 @@
+package gateway
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/protocol"
+)
+
+// When a hedge race produces no usable response, the batch item falls through to the normal
+// request path. That fallthrough must build a FRESH protocol context.
+//
+// race() hands the primary's protocol context a DETACHED parent (hedge.go: detachedHedgeCtx
+// + SetParentContext) and cancels it on every one of its exit paths (six call sites of
+// cancelBranches). Reusing that context on the fallthrough meant the relay failed instantly
+// with "context canceled" — it never reached the endpoint at all — and the batch path then
+// stamped that on whichever endpoint happened to be primary as a transport fault. Measured
+// 2026-09-05 on one batch-heavy service, every circuit break carried exactly that signature.
+//
+// The assertion is on ORDER, not on a count: the last relay must be preceded by a build.
+// A count alone passes on the buggy code, because the race builds a context for the hedge
+// endpoint too.
+func TestProcessSinglePayloadWithRetry_HedgeFallthroughRebuildsProtocolContext(t *testing.T) {
+	c := require.New(t)
+
+	const serviceID = "test-service"
+	primary := protocol.EndpointAddr("pokt1a-https://a.example.com")
+	hedge := protocol.EndpointAddr("pokt1b-https://b.example.net")
+
+	var mu sync.Mutex
+	var trace []string
+	record := func(event string) {
+		mu.Lock()
+		defer mu.Unlock()
+		trace = append(trace, event)
+	}
+
+	protocolCtx := &transportErrorProtocolCtx{
+		endpoint: primary,
+		onRelay:  func() { record("relay") },
+	}
+	proto := &pluggableCtxProtocol{
+		mockProtocolForRetry: mockProtocolForRetry{
+			retryConfig: &ServiceRetryConfig{
+				Enabled:    boolPtr(true),
+				MaxRetries: intPtr(0),
+				HedgeDelay: durationPtr(time.Millisecond),
+			},
+		},
+		endpoints:   protocol.EndpointAddrList{primary, hedge},
+		protocolCtx: protocolCtx,
+		onBuild:     func() { record("build") },
+	}
+
+	rc := &requestContext{
+		logger:              polyzero.NewLogger(),
+		context:             context.Background(),
+		serviceID:           serviceID,
+		qosCtx:              &recordingQoSContext{},
+		circuitBreaker:      NewDomainCircuitBreaker(nil, testCircuitBreakerLogger()),
+		protocol:            proto,
+		originalHTTPRequest: httptestRequest(),
+	}
+
+	payload := protocol.Payload{
+		Data:          `{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`,
+		RPCType:       sharedtypes.RPCType_JSON_RPC,
+		JSONRPCMethod: "eth_blockNumber",
+	}
+	_, err := rc.processSinglePayloadWithRetry(payload, 0, 2, sharedtypes.RPCType_JSON_RPC, rc.logger)
+	c.Error(err, "every relay in this test fails at the transport layer")
+
+	mu.Lock()
+	defer mu.Unlock()
+	c.GreaterOrEqual(len(trace), 2, "expected at least one build and one relay, got %v", trace)
+	c.Equal("relay", trace[len(trace)-1], "the fallthrough must end in a relay: %v", trace)
+	c.Equal("build", trace[len(trace)-2],
+		"the fallthrough relay must use a freshly built protocol context, not the one the "+
+			"hedge race cancelled: %v", trace)
+}

--- a/gateway/http_request_context_handle_request.go
+++ b/gateway/http_request_context_handle_request.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -217,6 +218,21 @@ func shouldCircuitBreak(heuristicResult *heuristic.AnalysisResult, httpStatusCod
 	// HTTP 4xx = client error. The domain correctly rejected a bad request.
 	// Don't punish domains for clients sending malformed requests.
 	if httpStatusCode >= 400 && httpStatusCode < 500 {
+		return false
+	}
+	// A cancellation is OURS by construction: an endpoint cannot cancel our context, only
+	// we can. A slow endpoint surfaces as context.DeadlineExceeded, which IS a signal about
+	// the endpoint and still breaks. Conflating the two benched operators for our own
+	// cancels — the hedge racer cancels the primary branch's detached context on every exit
+	// path, and a batch item that falls through from the race to the normal request path
+	// reused that dead context, producing "connection error: Post ...: context canceled"
+	// against a healthy endpoint. Measured 2026-09-05 on one batch-heavy service: every
+	// break carried this signature, and the three operators serving it from a single
+	// hostname each were locked out for hours at gate failure rates under 4%.
+	//
+	// Deliberately here rather than at one call site: MarkBroken has four callers and the
+	// invariant — we never bench a domain for a cancel we issued — belongs to all of them.
+	if lastErr != nil && errors.Is(lastErr, context.Canceled) {
 		return false
 	}
 	// Capability limitation errors (archival, lite fullnode, etc.) are expected from
@@ -1401,7 +1417,23 @@ func (rc *requestContext) processSinglePayloadWithRetry(
 				}
 				continue
 			}
-			// Hedge failed, fall through to normal request
+			// Hedge failed, fall through to normal request.
+			//
+			// race() hands protocolCtx a DETACHED parent context (hedge.go: SetParentContext)
+			// and cancels it on every exit path, so the context this ctx was built on is dead
+			// by the time we get here. Reusing it made the fallthrough fail instantly with
+			// "context canceled" — never reaching the endpoint at all — which then read as a
+			// transport fault of whichever endpoint happened to be primary. Rebuild so the
+			// fallthrough actually sends.
+			rebuiltCtx, _, rebuildErr := rc.protocol.BuildHTTPRequestContextForEndpoint(
+				rc.context, rc.serviceID, selectedEndpoint, rpcType, rc.originalHTTPRequest, true)
+			if rebuildErr != nil {
+				lastErr = rebuildErr
+				logger.Warn().Err(rebuildErr).Str("endpoint", string(selectedEndpoint)).
+					Msg("Failed to rebuild protocol context after hedge race")
+				continue
+			}
+			protocolCtx = rebuiltCtx
 		}
 
 		// Normal request path - send single payload

--- a/gateway/websocket_check_dedup_test.go
+++ b/gateway/websocket_check_dedup_test.go
@@ -1,0 +1,103 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/metrics"
+	shannonmetrics "github.com/pokt-network/path/metrics/protocol/shannon"
+	"github.com/pokt-network/path/protocol"
+)
+
+// wsDedupStatusCount reads path_health_check_status_total for one endpoint's derived
+// domain, using the same label derivation the executor uses so the test cannot drift.
+func wsDedupStatusCount(endpointAddr protocol.EndpointAddr, signal string) float64 {
+	domain, err := shannonmetrics.ExtractDomainOrHost(string(endpointAddr))
+	if err != nil {
+		domain = shannonmetrics.ErrDomain
+	}
+	rpcType := metrics.NormalizeRPCType(sharedtypes.RPCType_WEBSOCKET.String())
+	return testutil.ToFloat64(
+		metrics.HealthCheckStatus.WithLabelValues(domain, rpcType, string(wsCheckService), wsCheckName, signal),
+	)
+}
+
+// Suppliers sharing one backend websocket URL must cost ONE handshake, not one each.
+//
+// HTTP checks were deduplicated by backend URL; websocket checks were not, so a backend
+// carrying N supplier registrations took N full TCP+TLS+WS handshakes per cycle where HTTP
+// took one. Measured 2026-09-05: 29.85 websocket checks/s fleetwide, 6.62/s of them onto a
+// single operator, arriving as ~3/s of full-TLS handshakes per gateway egress IP. Stacked
+// registrations are common, so the multiplier tracked how a provider spread its
+// registrations rather than how much traffic it served.
+//
+// Endpoints on a DIFFERENT websocket URL are a different backend and must still be probed
+// directly — deduplicating those would stop testing a machine nobody else tests.
+func Test_WebsocketCheck_OneHandshakePerBackendURL(t *testing.T) {
+	c := require.New(t)
+
+	executor, proto, _, svcConfig := newWebsocketCheckExecutor(t, nil)
+
+	// Different REGISTRABLE domains, not just different hostnames: the metric label is
+	// eTLD+1, so two hosts under one registrable domain share a series and the two groups'
+	// records would be indistinguishable. That collapse is the same one that hid a
+	// per-hostname circuit-breaker lockout behind a healthy-looking per-operator series.
+	const sharedURL = "https://ws-shared.example.com"
+	const soloURL = "https://ws-solo.example.net"
+
+	shared := []EndpointInfo{
+		{Addr: protocol.EndpointAddr("pokt1a-" + sharedURL), WebSocketURL: sharedURL},
+		{Addr: protocol.EndpointAddr("pokt1b-" + sharedURL), WebSocketURL: sharedURL},
+		{Addr: protocol.EndpointAddr("pokt1c-" + sharedURL), WebSocketURL: sharedURL},
+		{Addr: protocol.EndpointAddr("pokt1d-" + sharedURL), WebSocketURL: sharedURL},
+	}
+	solo := EndpointInfo{Addr: protocol.EndpointAddr("pokt1e-" + soloURL), WebSocketURL: soloURL}
+
+	// An endpoint advertising no websocket URL is neither probed nor recorded.
+	noWS := EndpointInfo{Addr: protocol.EndpointAddr("pokt1f-" + sharedURL)}
+
+	members := append(append([]EndpointInfo{}, shared...), solo, noWS)
+
+	sharedOKBefore := wsDedupStatusCount(shared[0].Addr, metrics.SignalOK)
+	soloOKBefore := wsDedupStatusCount(solo.Addr, metrics.SignalOK)
+
+	executor.submitDedupedWebsocketChecks(context.Background(), wsCheckService, svcConfig, 0, members)
+	executor.wsPool.StopAndWait() // drain: websocket checks run off the cycle
+
+	// The whole point: 2 distinct backend websocket URLs => 2 handshakes, not 5.
+	c.EqualValues(2, proto.checksDispatched.Load(),
+		"expected one websocket handshake per distinct backend URL")
+
+	// The four suppliers behind the shared URL must ALL be recorded, not just the probed
+	// one. Skipping the siblings would leave them clean and selectable while the backend
+	// they share is broken — the endpoint gets reached anyway, via another supplier address.
+	c.EqualValues(sharedOKBefore+4, wsDedupStatusCount(shared[0].Addr, metrics.SignalOK),
+		"every supplier sharing the probed backend URL must be recorded")
+	c.EqualValues(soloOKBefore+1, wsDedupStatusCount(solo.Addr, metrics.SignalOK),
+		"an endpoint on its own backend URL must still be probed and recorded")
+}
+
+// Rotation: which supplier carries the handshake must advance with the cycle counter, so a
+// supplier's own websocket path is directly probed rather than one supplier answering for
+// the group forever.
+func Test_WebsocketCheck_HandshakeRotatesAcrossCycles(t *testing.T) {
+	c := require.New(t)
+
+	const sharedURL = "https://ws-rotate.example.com"
+	members := []EndpointInfo{
+		{Addr: protocol.EndpointAddr("pokt1a-" + sharedURL), WebSocketURL: sharedURL},
+		{Addr: protocol.EndpointAddr("pokt1b-" + sharedURL), WebSocketURL: sharedURL},
+		{Addr: protocol.EndpointAddr("pokt1c-" + sharedURL), WebSocketURL: sharedURL},
+	}
+
+	seen := map[int]struct{}{}
+	for cycle := uint64(0); cycle < uint64(len(members)); cycle++ {
+		seen[representativeIndex(cycle, len(members))] = struct{}{}
+	}
+	c.Len(seen, len(members),
+		"every supplier behind a shared backend URL must get a directly-probed turn")
+}

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -358,11 +358,15 @@ func (p *Protocol) CheckWebsocketConnection(
 		logger.Debug().Err(err).Msg("❌ Failed to connect to websocket endpoint")
 		return nil, getWebsocketConnectionErrorObservation(logger, serviceID, selectedEndpoint, err)
 	}
-	// Close with a handshake, not a bare socket drop. This probe runs ~89 times a second
+	// Close with a handshake, not a bare socket drop. This probe runs many times a second
 	// fleetwide, and a bare Close() makes every one of them surface in the endpoint's log
 	// as an abnormal closure (1006 / "Aborted state") attributed to the endpoint. 1000
 	// Normal Closure is accurate: the probe got what it came for and is leaving.
-	defer websockets.CloseEndpointConn(conn, gorillaws.CloseNormalClosure, "health check complete")
+	//
+	// The reason string is deliberately empty. The close CODE is what keeps these out of
+	// the endpoint's error budget; the text added nothing an operator could act on and
+	// only labelled every probe in their logs.
+	defer websockets.CloseEndpointConn(conn, gorillaws.CloseNormalClosure, "")
 
 	// Handshake-only probe: connecting was the whole test.
 	//

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -365,7 +365,7 @@ func (p *Protocol) CheckWebsocketConnection(
 	//
 	// The reason string is deliberately empty. The close CODE is what keeps these out of
 	// the endpoint's error budget; the text added nothing an operator could act on and
-	// only labelled every probe in their logs.
+	// only labeled every probe in their logs.
 	defer websockets.CloseEndpointConn(conn, gorillaws.CloseNormalClosure, "")
 
 	// Handshake-only probe: connecting was the whole test.

--- a/websockets/close_handshake_test.go
+++ b/websockets/close_handshake_test.go
@@ -45,7 +45,9 @@ func TestCloseEndpointConn_SendsCloseFrameInsteadOfDroppingTheSocket(t *testing.
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	require.NoError(t, err)
 
-	CloseEndpointConn(conn, websocket.CloseNormalClosure, "health check complete")
+	// Empty reason: the shipped health-check probe sends the code with no text, so the
+	// handshake has to stay clean without one.
+	CloseEndpointConn(conn, websocket.CloseNormalClosure, "")
 
 	select {
 	case err := <-closeErr:


### PR DESCRIPTION
Two independent gateway fixes found while diagnosing why one operator was receiving
no traffic on a batch-heavy service.

## 1. Circuit breaker benched domains for cancellations we issued

An endpoint cannot cancel our context — only we can — so `context.Canceled` is never
evidence about the endpoint. A genuinely slow endpoint surfaces as
`context.DeadlineExceeded`, which is a real signal and still breaks. The two were being
conflated.

An existing guard covered a cancel of the *client's* context. A second source went
straight past it: the hedge racer repoints the primary's protocol context at a detached
parent (`detachedHedgeCtx` + `SetParentContext`) and cancels that parent on every one of
its exit paths. When the race produced no usable response, the batch item fell through to
the normal request path and reused the same, now-dead, context — the relay failed
instantly with `context canceled` without ever reaching the endpoint, and that was stamped
on whichever endpoint happened to be primary.

Impact measured before the fix: one operator's endpoints were circuit-broken on 12–18 pods
near-continuously for six hours at a gate failure rate of 0.75%, while its traffic was
carried entirely by its second hostname.

Two changes:
- `shouldCircuitBreak` returns false for a wrapped `context.Canceled`. It lives in the
  shared decision function because `MarkBroken` has four callers and the invariant belongs
  to all of them.
- The hedge fallthrough builds a fresh protocol context instead of reusing the cancelled
  one, so the fallthrough actually sends.

## 2. Websocket health checks were not deduplicated by backend URL

HTTP checks were deduplicated per backend URL; websocket checks were explicitly not. A
backend carrying N supplier registrations took N full TCP+TLS+WS handshakes per cycle
where HTTP took one, so the cost tracked how a provider spread its registrations rather
than how much traffic it served. One operator was receiving roughly 3 handshakes per
second per gateway egress IP.

Now one handshake per distinct backend websocket URL, with the outcome recorded for every
supplier sharing that URL. Recording rather than skipping is load-bearing: a websocket
probe is a property of the backend, so a broken backend must move every sharing supplier's
websocket reputation key — otherwise only the probed supplier is penalized and the others
stay clean and selectable while fronting the same machine. The probing supplier rotates
with the cycle counter so each one's own path is still validated directly.

Also drops the text from the probe's close frame; the close code is what keeps these out
of an endpoint's error budget.

## Testing

Both fixes revert-checked — the fix removed, the test confirmed failing, the fix restored.

- `TestProcessSinglePayloadWithRetry_ClientCancelDoesNotFeedCircuitBreaker` — the control
  case previously used `context.Canceled` with a live parent and asserted it *should*
  break, which is the exact production shape asserted as correct, so it could not separate
  a cancel from a real fault. Control now uses `connection refused`, with a new case
  covering cancel-with-live-parent.
- `TestProcessSinglePayloadWithRetry_HedgeFallthroughRebuildsProtocolContext` — asserts on
  call ORDER (`build relay build relay`), because a count alone passes on the buggy code:
  the race also builds a context for the hedge endpoint.
- `Test_WebsocketCheck_OneHandshakePerBackendURL` — five endpoints across two backend URLs
  cost two handshakes, with all four sharing suppliers still recorded.

## Canary validation

Canary on this build, mainnet as control. Roughly ten minutes in:

- Zero `context canceled` breaks on canary across all services, in 25 captured break
  events. Before the fix, one operator alone produced 18 in fifteen minutes.
- On the affected service, canary recorded 1.06 breaks against mainnet's 5.29 over the
  same window, and mainnet is still breaking the operator that canary no longer breaks.
- Canary still produces `deadline` breaks, confirming the guard is not over-matching.

Note the websocket half is **not observable in existing metrics**:
`path_health_check_status_total` counts recorded results, and the fan deliberately keeps
one result per supplier, so the handshake reduction is real but invisible there. It is
covered by the unit test rather than by a production counter.
